### PR TITLE
Add likes funcionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import './style.css';
-import { getNasaApi, getDataDateImage } from './modules/API-links.js';
-import { getData } from './modules/get-post-data.js';
+import { getNasaApi, getDataDateImage, likeLink } from './modules/API-links.js';
+import { getData, postData } from './modules/get-post-data.js';
 import {
   containerDynamicCards,
   displayWindowPopup,
@@ -37,14 +37,59 @@ const displayImage = (idImg) => {
     .catch((error) => console.log(error));
 };
 
+const sendLikesDom = (idLike, likes) => {
+  const small = document.getElementById(idLike);
+  small.parentElement.nextElementSibling.innerHTML = `${likes} likes`;
+};
+
+function countingElementsFunc(elem) {
+  return elem.childElementCount;
+}
+
+const showFuncLikes = () => {
+  getData(likeLink)
+    .then((data) => data.forEach((card, index) => {
+      if (index < countingElementsFunc(containerDynamicCards)) {
+        sendLikesDom(card.item_id, card.likes);
+      }
+    }))
+    .catch((error) => console.log(error));
+};
+
 const showAmountOfLikes = () => {
   getData(getNasaApi)
     .then((data) => data.forEach((card, ind) => addFirstInterfaceCard(card.hdurl, card.title, ind)))
+    .then(() => {
+      showFuncLikes();
+    })
     .catch((error) => console.log(error));
 };
+
+const rawFunclike = (idLike, likes) => {
+  const data = { item_id: idLike };
+  postData(likeLink, data)
+    .then((data) => {
+      if (data.status === 201) {
+        sendLikesDom(idLike, likes);
+      }
+    })
+    .catch((error) => console.log(error));
+};
+
 showAmountOfLikes();
+rawFunclike();
 
 containerDynamicCards.addEventListener('click', (e) => {
+  // THIS WILL DISPLAY THE CORRESPONDING LIKES
+  // if (e.target.classList.contains('fa-heart')) {
+  //   e.preventDefault();
+  //   const likeCounter = parseInt(
+  //     e.target.parentElement.parentElement.nextElementSibling.textContent,
+  //     10,
+  //   );
+  //   const likes = likeCounter + 1;
+  //   rawFunclike(e.target.parentElement.id, likes);
+  // }
   if (e.target.classList.contains('comment')) {
     displayImage(parseInt(e.target.id, 10));
   }

--- a/src/modules/API-links.js
+++ b/src/modules/API-links.js
@@ -14,4 +14,6 @@ const randomDatesForPopupImgs = [
 
 const getDataDateImage = (num) => `https://api.nasa.gov/planetary/apod?api_key=yE5XwF3YBRu6RaMb2K328lXJabWCog5rzjaIR76N&date=${randomDatesForPopupImgs[num]}`;
 
-export { getNasaApi, getDataDateImage };
+const likeLink = 'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/rS93TYMaWFRcDHR1Rs9u/likes';
+
+export { getNasaApi, getDataDateImage, likeLink };


### PR DESCRIPTION
When the page loads, the webapp the [Involvement API](https://www.notion.so/microverse/Involvement-API-869e60b5ad104603aa6db59e08150270) to show the item likes and combines them with the data from the base API.

Remember that your page should make only 2 requests:

one to the base API
and one to the Involvement API.
This task does not include displaying the likes button (heart icon on the wireframe) for each item.